### PR TITLE
Release v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: Mahesh901122
 Donate link: https://www.paypal.me/mwaghmare7/
 Tags: Copy to Clipboard, Clipboard, Copy Anything to Clipboard
 Tested up to: 5.4
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 Requires PHP: 5.6
 Requires at least: 4.4
 
@@ -113,6 +113,10 @@ function my_slug_copy_the_code_localize_vars( $defaults )
 Yes, We have added `!important` for the Copy button to keep the button style same for each theme. We have tested below themes.
 
 == Changelog ==
+
+= 2.1.0 =
+
+* New: Added filter `copy_the_code_localize_vars` to allow to copy the content as HTMl instead of text.
 
 = 2.0.0 =
 

--- a/assets/js/copy-the-code.js
+++ b/assets/js/copy-the-code.js
@@ -152,25 +152,29 @@ window.CopyTheCodeToClipboard = (function(window, document, navigator) {
                 } else {
                     var source = btn.parents('.copy-the-code-wrap').find( selector );
                 }
-            
 
                 var html = source.html();
 
-                // Convert the <br/> tags into new line.
-                var brRegex = /<br\s*[\/]?>/gi;
-                html = html.replace(brRegex, "\n" );
+                if( 'html' !== copyTheCode.copy_content_as ) {
+                    // Convert the <br/> tags into new line.
+                    var brRegex = /<br\s*[\/]?>/gi;
+                    html = html.replace(brRegex, "\n" );
 
-                // Convert the <div> tags into new line.
-                var divRegex = /<div\s*[\/]?>/gi;
-                html = html.replace(divRegex, "\n" );
+                    // Convert the <div> tags into new line.
+                    var divRegex = /<div\s*[\/]?>/gi;
+                    html = html.replace(divRegex, "\n" );
 
-                // Convert the <p> tags into new line.
-                var pRegex = /<p\s*[\/]?>/gi;
-                html = html.replace(pRegex, "\n" );
+                    // Convert the <p> tags into new line.
+                    var pRegex = /<p\s*[\/]?>/gi;
+                    html = html.replace(pRegex, "\n" );
 
-                // Convert the <li> tags into new line.
-                var pRegex = /<li\s*[\/]?>/gi;
-                html = html.replace(pRegex, "\n" );
+                    // Convert the <li> tags into new line.
+                    var pRegex = /<li\s*[\/]?>/gi;
+                    html = html.replace(pRegex, "\n" );
+
+                    // Remove all tags.
+                    html = html.replace( /(<([^>]+)>)/ig, '');
+                }
 
                 // Remove white spaces.
                 var reWhiteSpace = new RegExp("/^\s+$/");
@@ -180,16 +184,22 @@ window.CopyTheCodeToClipboard = (function(window, document, navigator) {
                 $("body").append(tempElement);
                 html = $.trim( html );
                 $('#temp-element').html( html );
-                var html = $('#temp-element').text();
+                var html = $('#temp-element').html();
                 $('#temp-element').remove();
 
-                // Remove the 'copy' text.
-                var tempHTML = html.replace(button_text, '');
+                var tempHTML = html;
+                console.log( tempHTML );
 
                 var buttonMarkup = CopyTheCode._getButtonMarkup( button_title, button_text, style );
+                console.log( buttonMarkup );
 
                 // Remove the <copy> button.
-                var tempHTML = tempHTML.replace(buttonMarkup, '');
+                tempHTML = tempHTML.replace(buttonMarkup, '');
+                // console.log( buttonMarkup );
+                // console.log( tempHTML );
+
+                // Remove button text.
+                tempHTML = tempHTML.replace(button_text, '');
 
             // Copy the Code.
             var tempPre = $("<textarea id='temp-pre'>"),

--- a/classes/class-copy-the-code-page.php
+++ b/classes/class-copy-the-code-page.php
@@ -346,18 +346,19 @@ if ( ! class_exists( 'Copy_The_Code_Page' ) ) :
 			return apply_filters(
 				'copy_the_code_localize_vars',
 				array(
-					'previewMarkup' => '&lt;h2&gt;Hello World&lt;/h2&gt;',
-					'buttonMarkup'  => '<button class="copy-the-code-button" title=""></button>',
-					'buttonSvg'     => '<svg viewBox="-21 0 512 512" xmlns="http://www.w3.org/2000/svg"><path d="m186.667969 416c-49.984375 0-90.667969-40.683594-90.667969-90.667969v-218.664062h-37.332031c-32.363281 0-58.667969 26.300781-58.667969 58.664062v288c0 32.363281 26.304688 58.667969 58.667969 58.667969h266.664062c32.363281 0 58.667969-26.304688 58.667969-58.667969v-37.332031zm0 0"></path><path d="m469.332031 58.667969c0-32.40625-26.261719-58.667969-58.664062-58.667969h-224c-32.40625 0-58.667969 26.261719-58.667969 58.667969v266.664062c0 32.40625 26.261719 58.667969 58.667969 58.667969h224c32.402343 0 58.664062-26.261719 58.664062-58.667969zm0 0"></path></svg>',
-					'selectors'     => $selectors,
-					'selector'      => 'pre', // Selector in which have the actual `<code>`.
-					'settings'      => $this->get_page_settings(),
-					'string'        => array(
+					'copy_content_as' => '',
+					'previewMarkup'   => '&lt;h2&gt;Hello World&lt;/h2&gt;',
+					'buttonMarkup'    => '<button class="copy-the-code-button" title=""></button>',
+					'buttonSvg'       => '<svg viewBox="-21 0 512 512" xmlns="http://www.w3.org/2000/svg"><path d="m186.667969 416c-49.984375 0-90.667969-40.683594-90.667969-90.667969v-218.664062h-37.332031c-32.363281 0-58.667969 26.300781-58.667969 58.664062v288c0 32.363281 26.304688 58.667969 58.667969 58.667969h266.664062c32.363281 0 58.667969-26.304688 58.667969-58.667969v-37.332031zm0 0"></path><path d="m469.332031 58.667969c0-32.40625-26.261719-58.667969-58.664062-58.667969h-224c-32.40625 0-58.667969 26.261719-58.667969 58.667969v266.664062c0 32.40625 26.261719 58.667969 58.667969 58.667969h224c32.402343 0 58.664062-26.261719 58.664062-58.667969zm0 0"></path></svg>',
+					'selectors'       => $selectors,
+					'selector'        => 'pre', // Selector in which have the actual `<code>`.
+					'settings'        => $this->get_page_settings(),
+					'string'          => array(
 						'title'  => $this->get_page_setting( 'button-title', __( 'Copy to Clipboard', 'copy-the-code' ) ),
 						'copy'   => $this->get_page_setting( 'button-text', __( 'Copy', 'copy-the-code' ) ),
 						'copied' => $this->get_page_setting( 'button-copy-text', __( 'Copied!', 'copy-the-code' ) ),
 					),
-					'image-url'     => COPY_THE_CODE_URI . '/assets/images/copy-1.svg',
+					'image-url'       => COPY_THE_CODE_URI . '/assets/images/copy-1.svg',
 				)
 			);
 		}

--- a/copy-the-code.php
+++ b/copy-the-code.php
@@ -3,7 +3,7 @@
  * Plugin Name: Copy Anything to Clipboard
  * Plugin URI: https://github.com/maheshwaghmare/copy-the-code/
  * Description: Copy the Text or HTML into the clipboard 📋 (clipboard). You can use it for code snippets, special symbols, discount codes, or anything which you want. By default it add the copy to clipboard button to the <code>&lt;pre&gt;</code> tag. Documentations and more visit <a href="https://maheshwaghmare.com/doc/copy-anything-to-clipboard/"> on GitHub</a>.
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author: Mahesh M. Waghmare
  * Author URI: https://maheshwaghmare.wordpress.com/
  * Text Domain: copy-the-code
@@ -13,7 +13,7 @@
 
 // Set constants.
 define( 'COPY_THE_CODE_TITLE', esc_html__( 'Copy Anything to Clipboard', 'copy-the-code' ) );
-define( 'COPY_THE_CODE_VER', '2.0.0' );
+define( 'COPY_THE_CODE_VER', '2.1.0' );
 define( 'COPY_THE_CODE_FILE', __FILE__ );
 define( 'COPY_THE_CODE_BASE', plugin_basename( COPY_THE_CODE_FILE ) );
 define( 'COPY_THE_CODE_DIR', plugin_dir_path( COPY_THE_CODE_FILE ) );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Mahesh901122
 Donate link: https://www.paypal.me/mwaghmare7/
 Tags: Copy to Clipboard, Clipboard, Copy Anything to Clipboard
 Tested up to: 5.4
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 Requires at least: 4.4
 
 Copy the Text or HTML into the clipboard 📋 (clipboard). You can use it for code snippets, special symbols, discount codes, or anything which you want. By default it add the copy to clipboard button to the <code>&lt;pre&gt;</code> tag.
@@ -126,6 +126,10 @@ function my_slug_copy_the_code_localize_vars( $defaults )
 Yes, We have added `!important` for the Copy button to keep the button style same for each theme. We have tested below themes.
 
 == Changelog ==
+
+= 2.1.0 =
+
+* New: Added filter `copy_the_code_localize_vars` to allow to copy the content as HTMl instead of text.
 
 = 2.0.0 =
 


### PR DESCRIPTION
* New: Added filter `copy_the_code_localize_vars` to allow to copy the content as HTMl instead of text.

E.g.

```php
/**
 * Allow to copy as HTML.
 * 
 * @todo Change the `prefix_` and with your own unique prefix.
 * 
 * @since 1.0.0
 * 
 * @return mixed
 */
if( ! function_exists( 'prefix_allow_copy_as_html' ) ) :
	function prefix_allow_copy_as_html( $args = array() ) {
		
		// Allow to copy content as HTML.
		$args['copy_content_as'] = 'html';
		
		return $args;
   	}
  	add_filter( 'copy_the_code_localize_vars', 'prefix_allow_copy_as_html' );
endif;
```

See https://gist.github.com/ac657e64450d1622a1e74a45f4f0cef2